### PR TITLE
Introduce Internal Iterative Reductions

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -412,7 +412,7 @@ public class AlphaBeta
 		
 		if(isPV && ttMove == null)
 		{
-			depth --;
+			depth -= 2;
 		}
 
 		for (Move move : legalMoves)

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -96,7 +96,7 @@ public class AlphaBeta
 		return System.nanoTime() > this.timeLimit;
 	}
 
-	private List<Move> sortMoves(List<Move> moves, Board board, int ply)
+	private Move sortMoves(List<Move> moves, Board board, int ply)
 	{
 		List<Move> captures = new ArrayList<Move>();
 //		List<Move> promotions = new ArrayList<Move>();
@@ -234,7 +234,7 @@ public class AlphaBeta
 //			moves.addAll(1, promotions);
 //		}
 
-		return moves;
+		return ttMoves.isEmpty() ? null : ttMoves.get(0);
 	}
 
 	private List<Move> sortCaptures(List<Move> moves, Board board)
@@ -408,7 +408,12 @@ public class AlphaBeta
 
 		boolean inCheckBefore = board.isKingAttacked();
 
-		sortMoves(legalMoves, board, ply);
+		Move ttMove = sortMoves(legalMoves, board, ply);
+		
+		if(isPV && ttMove == null)
+		{
+			depth --;
+		}
 
 		for (Move move : legalMoves)
 		{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -29,6 +29,8 @@ public class AlphaBeta
 	private Move[] killers;
 	private Move[][] counterMoves;
 	private int[][] history;
+	
+	private int rootDepth;
 
 	public AlphaBeta()
 	{
@@ -410,7 +412,7 @@ public class AlphaBeta
 
 		Move ttMove = sortMoves(legalMoves, board, ply);
 		
-		if(isPV && ttMove == null)
+		if(isPV && ttMove == null && rootDepth > 2 && depth > 5)
 		{
 			depth -= 2;
 		}
@@ -521,6 +523,7 @@ public class AlphaBeta
 		{
 			for (int i = 1; i <= targetDepth; i++)
 			{
+				rootDepth = i;
 				if (i > 3)
 				{
 					int newScore = mainSearch(board, i, currentScore - ASPIRATION_DELTA,


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 1828 - 1572 - 1456 [] 4856
Elo difference: 18.33 +/- 8.17, LOS: 100.00 %, DrawRatio: 29.98 %