### PR TITLE
Introduce Reverse Futility Pruning

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -384,6 +384,11 @@ public class AlphaBeta
 		{
 			staticEval = PeSTO.evaluate(board);
 		}
+		
+		if (!isPV && !board.isKingAttacked() && depth < 7 && staticEval > beta && staticEval - depth * 1680 > beta)
+		{
+			return beta;
+		}
 
 		if (nullAllowed && beta < MATE_EVAL - 1024 && !board.isKingAttacked()
 				&& (board.getBitboard(Piece.make(board.getSideToMove(), PieceType.KING)) | board


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 196 - 117 - 113 [] 425
Elo difference: 65.18 +/- 28.62, LOS: 100.00 %, DrawRatio: 26.53 %