### PR TITLE
Prune in Qsearch when SEE < 0

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -186,6 +186,11 @@ public class AlphaBeta
 				bestScore = Math.max(bestScore, futilityBase);
 				continue;
 			}
+			
+			if (!inCheck && !SEE.staticExchangeEvaluation(board, move, 0))
+			{
+				continue;
+			}
 
 			board.doMove(move);
 


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 249 - 126 - 233 [] 608
Elo difference: 71.27 +/- 21.85, LOS: 100.00 %, DrawRatio: 38.32 %