### PR TITLE
Lower SEE Pruning bounds

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -187,7 +187,7 @@ public class AlphaBeta
 				continue;
 			}
 			
-			if (!inCheck && !SEE.staticExchangeEvaluation(board, move, 0))
+			if (!inCheck && !SEE.staticExchangeEvaluation(board, move, -20))
 			{
 				continue;
 			}


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 291 - 162 - 261 [] 713
Elo difference: 63.47 +/- 20.43, LOS: 100.00 %, DrawRatio: 36.55 %