### PR TITLE
Adjust LMR Conditions

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -596,7 +596,7 @@ public class AlphaBeta
 
 			int thisMoveEval = MIN_EVAL;
 
-			if (moveCount > 3 && depth > 3)
+			if (moveCount > 2 + (ply == 0 ? 1 : 0) && depth > 2)
 			{
 				int r = (int) (1.35 + Math.log(depth) * Math.log(moveCount) / 2.75);
 


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 1553 - 1397 - 2082 [] 5032
Elo difference: 10.77 +/- 7.34, LOS: 99.80 %, DrawRatio: 41.38 %