### PR TITLE
Soft Time Limit

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -703,7 +703,7 @@ public class AlphaBeta
 		this.nodesLimit = nodesLimit;
 		long startTime = System.nanoTime();
 		this.timeLimit = System.nanoTime() + msLeft * 1000000L;
-		long softTimeLimit = System.nanoTime() + msLeft * 600000L;
+		long softTimeLimit = System.nanoTime() + msLeft * 500000L;
 		this.history = new int[13][65];
 		this.whiteAccumulator = new NNUEAccumulator(network);
 		this.blackAccumulator = new NNUEAccumulator(network);

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -703,7 +703,7 @@ public class AlphaBeta
 		this.nodesLimit = nodesLimit;
 		long startTime = System.nanoTime();
 		this.timeLimit = System.nanoTime() + msLeft * 1000000L;
-		long softTimeLimit = System.nanoTime() + msLeft * 800000L;
+		long softTimeLimit = System.nanoTime() + msLeft * 600000L;
 		this.history = new int[13][65];
 		this.whiteAccumulator = new NNUEAccumulator(network);
 		this.blackAccumulator = new NNUEAccumulator(network);

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -720,7 +720,7 @@ public class AlphaBeta
 
 		try
 		{
-			for (int i = 1; i <= targetDepth && System.nanoTime() < softTimeLimit; i++)
+			for (int i = 1; i <= targetDepth && (i < 4 || System.nanoTime() < softTimeLimit); i++)
 			{
 				rootDepth = i;
 				selDepth = 0;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -703,6 +703,7 @@ public class AlphaBeta
 		this.nodesLimit = nodesLimit;
 		long startTime = System.nanoTime();
 		this.timeLimit = System.nanoTime() + msLeft * 1000000L;
+		long softTimeLimit = System.nanoTime() + msLeft * 800000L;
 		this.history = new int[13][65];
 		this.whiteAccumulator = new NNUEAccumulator(network);
 		this.blackAccumulator = new NNUEAccumulator(network);
@@ -719,7 +720,7 @@ public class AlphaBeta
 
 		try
 		{
-			for (int i = 1; i <= targetDepth; i++)
+			for (int i = 1; i <= targetDepth && System.nanoTime() < softTimeLimit; i++)
 			{
 				rootDepth = i;
 				selDepth = 0;


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 830 - 705 - 1519 [] 3054
Elo difference: 14.23 +/- 8.73, LOS: 99.93 %, DrawRatio: 49.74 %