### PR TITLE
Adjust NMP reduction formula

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -527,10 +527,10 @@ public class AlphaBeta
 								.getBitboard(board.getSideToMove())
 				&& evaluate(board) >= beta && ply > 0 && staticEval >= beta)
 		{
-//			int r = depth / 3 + 4;
+			int r = depth / 3 + 4;
 
 			board.doNullMove();
-			int nullEval = -mainSearch(board, depth - 4, -beta, -beta + 1, ply + 1, false);
+			int nullEval = -mainSearch(board, depth - r, -beta, -beta + 1, ply + 1, false);
 			board.undoMove();
 
 			if (nullEval >= beta && nullEval < MATE_EVAL - 1024)


### PR DESCRIPTION
Score of Serendipity-Test vs Serendipity-Stable: 603 - 485 - 1096 [] 2183
Elo difference: 18.79 +/- 10.27, LOS: 99.98 %, DrawRatio: 50.18 %