### PR TITLE
Fix NMP Guard

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -521,7 +521,7 @@ public class AlphaBeta
 				&& (board.getBitboard(Piece.make(board.getSideToMove(), PieceType.KING))
 						| board.getBitboard(Piece.make(board.getSideToMove(), PieceType.PAWN))) != board
 								.getBitboard(board.getSideToMove())
-				&& evaluate(board) >= beta && ply > 0 && staticEval >= beta)
+				&& staticEval >= beta && ply > 0)
 		{
 			int r = depth / 3 + 4;
 


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Score of Serendipity-Test vs Serendipity-Stable: 185 - 122 - 397 [0.545] 703
Elo difference: 31.17 +/- 16.92, LOS: 99.98 %, DrawRatio: 56.39 %