### PR TITLE
Disable TT Cutoffs in PV nodes

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -502,7 +502,7 @@ public class AlphaBeta
 		
 		ss.ttHit = currentMoveEntry != null;
 
-		if ((!isPV || ply > 1) && currentMoveEntry != null && currentMoveEntry.getDepth() >= depth
+		if (!isPV && currentMoveEntry != null && currentMoveEntry.getDepth() >= depth
 				&& currentMoveEntry.getSignature() == board.getIncrementalHashKey())
 		{
 			int eval = currentMoveEntry.getEvaluation();


### PR DESCRIPTION
Passed 20+0.2 non-reg:

Score of Serendipity-Test vs Serendipity-Stable: 144 - 123 - 447 [0.515] 713
Elo difference: 10.22 +/- 15.57, LOS: 90.06 %, DrawRatio: 62.61 %