### PR TITLE
Dampen eval when shuffling

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -133,8 +133,9 @@ public class AlphaBeta
 
 	public int evaluate(Board board)
 	{
-		return (Side.WHITE.equals(board.getSideToMove()) ? NNUE.evaluate(network, whiteAccumulator, blackAccumulator)
+		int v = (Side.WHITE.equals(board.getSideToMove()) ? NNUE.evaluate(network, whiteAccumulator, blackAccumulator)
 				: NNUE.evaluate(network, blackAccumulator, whiteAccumulator)) * 24;
+		return v * (200 - board.getHalfMoveCounter()) / 200;
 	}
 
 	private void sortMoves(List<Move> moves, Board board, int ply)


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Score of Serendipity-Test vs Serendipity-Stable: 619 - 531 - 1318 [0.518] 2468
Elo difference: 12.39 +/- 9.34, LOS: 99.53 %, DrawRatio: 53.40 %