### PR TITLE
Allow TT Cutoffs in Qsearch

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -550,6 +550,34 @@ public class AlphaBeta
 			return DRAW_EVAL;
 		}
 
+		boolean isPV = beta - alpha > 1;
+
+		TranspositionTable.Entry currentMoveEntry = tt.probe(board.getIncrementalHashKey());
+
+		if (!isPV && currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
+		{
+			int eval = currentMoveEntry.getEvaluation();
+			switch (currentMoveEntry.getType())
+			{
+				case EXACT:
+					return eval;
+				case UPPERBOUND:
+					if (eval <= alpha)
+					{
+						return eval;
+					}
+					break;
+				case LOWERBOUND:
+					if (eval > beta)
+					{
+						return eval;
+					}
+					break;
+				default:
+					throw new IllegalArgumentException("Unexpected value: " + currentMoveEntry.getType());
+			}
+		}
+
 		int futilityBase;
 		boolean inCheck = searchStack[ply].inCheck = board.isKingAttacked();
 		final List<Move> moves;


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [-10.00, 8.00]
Score of Serendipity-Test vs Serendipity-Stable: 88 - 60 - 140 [0.549] 287
Elo difference: 33.89 +/- 28.80, LOS: 98.93 %, DrawRatio: 48.61 %