### PR TITLE
Introduce Late Move Pruning (Move Count Pruning)

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -784,7 +784,9 @@ public class AlphaBeta
 		{
 			ss.moveCount++;
 			int newdepth = depth - 1;
-			boolean isQuiet = Piece.NONE.equals(move.getPromotion()) && Piece.NONE.equals(board.getPiece(move.getTo()));
+			boolean isQuiet = Piece.NONE.equals(move.getPromotion()) && Piece.NONE.equals(board.getPiece(move.getTo()))
+					&& !(PieceType.PAWN.equals(board.getPiece(move.getTo()).getPieceType())
+							&& move.getTo() == board.getEnPassant());
 
 			if (alpha > -MATE_EVAL + 1024 && depth < 9
 					&& !SEE.staticExchangeEvaluation(board, move, isQuiet ? -65 * depth : -38 * depth * depth))
@@ -912,9 +914,9 @@ public class AlphaBeta
 		this.nodesLimit = limits.getNodes();
 		this.timeManager = new TimeManager(limits.getTime(), limits.getIncrement(), limits.getMovesToGo(), 100,
 				board.getMoveCounter());
-		for (int i = 0;i < 13; i ++)
+		for (int i = 0; i < 13; i++)
 		{
-			for (int j = 0; j < 65; j ++)
+			for (int j = 0; j < 65; j++)
 			{
 				history[i][j] /= 5;
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -788,6 +788,11 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
+			if (isQuiet && !isPV && depth <= 6 && ss.moveCount > 3 + depth * depth)
+			{
+				continue;
+			}
+
 			if (alpha > -MATE_EVAL + 1024 && depth < 9
 					&& !SEE.staticExchangeEvaluation(board, move, isQuiet ? -65 * depth : -38 * depth * depth))
 			{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -788,7 +788,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && depth <= 6 && ss.moveCount > 3 + depth * depth && alpha > -MATE_EVAL + 1024)
+			if (isQuiet && !isPV && !inCheck && depth <= 6 && ss.moveCount > 3 + depth * depth && alpha > -MATE_EVAL + 1024)
 			{
 				continue;
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -785,7 +785,7 @@ public class AlphaBeta
 			ss.moveCount++;
 			int newdepth = depth - 1;
 			boolean isQuiet = Piece.NONE.equals(move.getPromotion()) && Piece.NONE.equals(board.getPiece(move.getTo()))
-					&& !(PieceType.PAWN.equals(board.getPiece(move.getTo()).getPieceType())
+					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
 			if (alpha > -MATE_EVAL + 1024 && depth < 9

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -788,7 +788,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && depth <= 6 && ss.moveCount > 3 + depth * depth)
+			if (isQuiet && !isPV && depth <= 6 && ss.moveCount > 3 + depth * depth && alpha > -MATE_EVAL + 1024)
 			{
 				continue;
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
@@ -60,7 +60,7 @@ public class MoveSort
 		}
 
 		if (!board.getPiece(move.getTo()).equals(Piece.NONE)
-				|| (PieceType.PAWN.equals(board.getPiece(move.getTo()).getPieceType())
+				|| (PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 						&& move.getTo() == board.getEnPassant()))
 		{
 			int score = SEE.staticExchangeEvaluation(board, move, -20) ? 900000000 : -1000000;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
@@ -59,7 +59,9 @@ public class MoveSort
 			};
 		}
 
-		if (!board.getPiece(move.getTo()).equals(Piece.NONE))
+		if (!board.getPiece(move.getTo()).equals(Piece.NONE)
+				|| (PieceType.PAWN.equals(board.getPiece(move.getTo()).getPieceType())
+						&& move.getTo() == board.getEnPassant()))
 		{
 			int score = SEE.staticExchangeEvaluation(board, move, -20) ? 900000000 : -1000000;
 			score += pieceValue(board.getPiece(move.getTo())) * 100000 - pieceValue(board.getPiece(move.getFrom()));


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Score of Serendipity-Test vs Serendipity-Stable: 942 - 838 - 1958 [0.514] 3739
Elo difference: 9.67 +/- 7.68, LOS: 99.32 %, DrawRatio: 52.38 %