### PR TITLE
Retain previous TTMove after fail low

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -523,7 +523,7 @@ public class AlphaBeta
 
 		if (alpha == oldAlpha)
 		{
-			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, null);
+			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, ttMove);
 		}
 
 		else if (alpha > oldAlpha)

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -523,7 +523,7 @@ public class AlphaBeta
 
 		if (alpha == oldAlpha)
 		{
-			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, bestMove);
+			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, null);
 		}
 
 		else if (alpha > oldAlpha)


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Score of Serendipity-Test vs Serendipity-Stable: 305W - 201L - 262D [0.568] 767
Elo difference: 47.34 +/- 18.92, nElo difference: 62.31 +/- 24.57, LOS: 100.00 %, PairDrawRatio: 34.11 %
Tournament finishedFinished tournament.
