### PR TITLE
Increase Reduction In Non-PV Nodes

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -478,7 +478,7 @@ public class AlphaBeta
 			{
 				int r = (int) (1.60 + Math.log(depth) * Math.log(ss.moveCount) / 2.17);
 
-//				r += isPV ? 0 : 1;
+				r += isPV ? 0 : 1;
 				r -= givesCheck ? 1 : 0;
 //
 //				r = Math.max(0, Math.min(depth - 1, r));


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 5.00]
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 4.85 +/- 3.70, nElo: 7.29 +/- 5.56
LOS: 99.49 %, DrawRatio: 41.39 %, PairsRatio: 1.08
Games: 14978, Wins: 4474, Losses: 4265, Draws: 6239, Points: 7593.50 (50.70 %)
Ptnml(0-2): [355, 1752, 3100, 1893, 389]