### PR TITLE
NNUE Performance Improvements

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/NNUE/NNUE.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/NNUE/NNUE.java
@@ -36,6 +36,16 @@ public class NNUE
 	private final short[] L1Biases;
 	private final short[][] L2Weights;
 	private final short outputBiases[];
+	
+	private final static int screlu[] = new int[Short.MAX_VALUE - Short.MIN_VALUE + 1];
+	
+	static
+	{
+		for(int i = Short.MIN_VALUE; i <= Short.MAX_VALUE;i ++)
+		{
+			screlu[i - (int) Short.MIN_VALUE] = screlu((short)(i));
+		}
+	}
 
 	public static class NNUEAccumulator
 	{
@@ -144,13 +154,13 @@ public class NNUE
 			L1Biases[i] = toLittleEndian(networkData.readShort());
 		}
 
-		L2Weights = new short[HIDDEN_SIZE * 2][OUTPUT_BUCKETS];
+		L2Weights = new short[OUTPUT_BUCKETS][HIDDEN_SIZE * 2];
 
 		for (int i = 0; i < HIDDEN_SIZE * 2; i++)
 		{
 			for (int j = 0; j < OUTPUT_BUCKETS; j++)
 			{
-				L2Weights[i][j] = toLittleEndian(networkData.readShort());
+				L2Weights[j][i] = toLittleEndian(networkData.readShort());
 			}
 		}
 
@@ -176,8 +186,8 @@ public class NNUE
 
 		for (int i = 0; i < HIDDEN_SIZE; i++)
 		{
-			eval += screlu(us.values[i]) * (int) network.L2Weights[i][chosenBucket]
-					+ screlu(them.values[i]) * (int) network.L2Weights[i + HIDDEN_SIZE][chosenBucket];
+			eval += screlu[us.values[i] - (int) Short.MIN_VALUE] * (int) network.L2Weights[chosenBucket][i]
+					+ screlu[them.values[i] - (int) Short.MIN_VALUE] * (int) network.L2Weights[chosenBucket][i + HIDDEN_SIZE];
 		}
 
 		eval /= QA;


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 39.18 +/- 15.52, nElo: 63.42 +/- 24.90
LOS: 100.00 %, DrawRatio: 44.92 %, PairsRatio: 1.90
Games: 748, Wins: 254, Losses: 170, Draws: 324, Points: 416.0 (55.61 %)
Ptnml(0-2): [6, 65, 168, 109, 26]