### PR TITLE
Double Extend Singular Nodes

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -457,7 +457,7 @@ public class AlphaBeta
 
 				if (singularValue < singularBeta)
 				{
-					extension = 1;
+					extension = 2;
 				}
 
 			}


### PR DESCRIPTION
SPRT test finished: (-2.94, 2.94) [0.00, 8.00]
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 7.59 +/- 5.62, nElo: 13.20 +/- 9.77
LOS: 99.59 %, DrawRatio: 48.35 %, PairsRatio: 1.20
Games: 4856, Wins: 1270, Losses: 1164, Draws: 2422, Points: 2481.0 (51.09 %)
Ptnml(0-2): [64, 505, 1174, 631, 54]