### PR TITLE
Switch to Butterfly History

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -64,7 +64,7 @@ public class AlphaBeta
 		this.nodesLimit = -1;
 		this.pv = new Move[MAX_PLY][MAX_PLY];
 		this.counterMoves = new Move[13][65];
-		this.history = new PieceToHistory();
+		this.history = new FromToHistory();
 		this.rootDepth = 0;
 		this.searchStack = newSearchStack();
 
@@ -654,7 +654,7 @@ public class AlphaBeta
 		this.pv = new Move[MAX_PLY][MAX_PLY];
 		this.searchStack = newSearchStack();
 		this.counterMoves = new Move[13][65];
-		this.history = new PieceToHistory();
+		this.history = new FromToHistory();
 		this.rootDepth = 0;
 		this.selDepth = 0;
 	}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -33,7 +33,7 @@ public class AlphaBeta
 
 	private Move[][] pv;
 	private Move[][] counterMoves;
-	private PieceToHistory history;
+	private History history;
 
 	private int rootDepth;
 	private int selDepth;
@@ -534,14 +534,14 @@ public class AlphaBeta
 
 					for (Move quietMove : quietMovesFailBeta)
 					{
-						history.register(board.getPiece(quietMove.getFrom()), quietMove.getTo(), stat_malus(depth));
+						history.register(board, quietMove, stat_malus(depth));
 					}
 
 					if (isQuiet)
 					{
 						ss.killer = move;
 
-						history.register(board.getPiece(move.getFrom()), move.getTo(), stat_bonus(depth));
+						history.register(board, move, stat_bonus(depth));
 
 						if (lastMove != null)
 						{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/FromToHistory.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/FromToHistory.java
@@ -1,0 +1,53 @@
+package org.shawn.games.Serendipity;
+
+import com.github.bhlangonijr.chesslib.*;
+import com.github.bhlangonijr.chesslib.move.Move;
+
+public class FromToHistory implements History
+{
+	private int[] history;
+
+	static final int MAX_BONUS = 16384;
+
+	final int DIMENSION = Square.values().length;
+
+	public FromToHistory()
+	{
+		history = new int[DIMENSION * DIMENSION];
+	}
+
+	public int get(Square from, Square to)
+	{
+		return history[from.ordinal() * DIMENSION + to.ordinal()];
+	}
+
+	public int get(Move move)
+	{
+		return get(move.getFrom(), move.getTo());
+	}
+
+	private static int clamp(int v, int max, int min)
+	{
+		return v >= max ? max : (v <= min ? min : v);
+	}
+
+	public void register(Square from, Square to, int value)
+	{
+		int clampedValue = clamp(value, MAX_BONUS, -MAX_BONUS);
+
+		history[from.ordinal() * DIMENSION + to.ordinal()] += clampedValue
+				- history[from.ordinal() * DIMENSION + to.ordinal()] * Math.abs(clampedValue) / MAX_BONUS;
+	}
+
+	@Override
+	public int get(Board board, Move move)
+	{
+		return get(move.getFrom(), move.getTo());
+	}
+
+	@Override
+	public void register(Board board, Move move, int value)
+	{
+		register(move.getFrom(), move.getTo(), value);
+	}
+}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/History.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/History.java
@@ -1,0 +1,10 @@
+package org.shawn.games.Serendipity;
+
+import com.github.bhlangonijr.chesslib.*;
+import com.github.bhlangonijr.chesslib.move.*;
+
+public interface History
+{
+	public int get(Board board, Move move);
+	public void register(Board board, Move move, int value);
+}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/MoveSort.java
@@ -42,7 +42,7 @@ public class MoveSort
 		return 0;
 	}
 
-	public static int moveValue(Move move, Move ttMove, Move killer, Move counterMove, PieceToHistory history, Board board)
+	public static int moveValue(Move move, Move ttMove, Move killer, Move counterMove, History history, Board board)
 	{
 		if (move.equals(ttMove))
 		{
@@ -78,10 +78,10 @@ public class MoveSort
 			return 700000000;
 		}
 
-		return history.get(board.getPiece(move.getFrom()), move.getTo());
+		return history.get(board, move);
 	}
 
-	public static void sortMoves(List<Move> moves, Move ttMove, Move killer, Move counterMove, PieceToHistory history,
+	public static void sortMoves(List<Move> moves, Move ttMove, Move killer, Move counterMove, History history,
 			Board board)
 	{
 		moves.sort(new Comparator<Move>() {

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/PieceToHistory.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/PieceToHistory.java
@@ -3,7 +3,7 @@ package org.shawn.games.Serendipity;
 import com.github.bhlangonijr.chesslib.*;
 import com.github.bhlangonijr.chesslib.move.Move;
 
-public class PieceToHistory
+public class PieceToHistory implements History
 {
 	private int[][] history;
 
@@ -35,5 +35,17 @@ public class PieceToHistory
 
 		history[piece.ordinal()][to.ordinal()] += clampedValue
 				- history[piece.ordinal()][to.ordinal()] * Math.abs(clampedValue) / MAX_BONUS;
+	}
+
+	@Override
+	public int get(Board board, Move move)
+	{
+		return get(board.getPiece(move.getFrom()), move.getTo());
+	}
+
+	@Override
+	public void register(Board board, Move move, int value)
+	{
+		register(board.getPiece(move.getFrom()), move.getTo(), value);
 	}
 }


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 6.31 +/- 4.16, nElo: 9.42 +/- 6.22
LOS: 99.85 %, DrawRatio: 42.94 %, PairsRatio: 1.07
Games: 12004, Wins: 3776, Losses: 3558, Draws: 4670, Points: 6111.0 (50.91 %)
Ptnml(0-2): [275, 1381, 2577, 1389, 380]
LLR: 2.95 (-2.94, 2.94) [0.00, 4.00]