### PR TITLE
Make Evaluation Scale Normal

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -9,11 +9,11 @@ import com.github.bhlangonijr.chesslib.move.*;
 
 public class AlphaBeta
 {
-	private final int PAWN_VALUE = 82;
-	private final int KNIGHT_VALUE = 337;
-	private final int BISHOP_VALUE = 365;
-	private final int ROOK_VALUE = 477;
-	private final int QUEEN_VALUE = 1025;
+	private static final int PAWN_VALUE = 82;
+	private static final int KNIGHT_VALUE = 337;
+	private static final int BISHOP_VALUE = 365;
+	private static final int ROOK_VALUE = 477;
+	private static final int QUEEN_VALUE = 1025;
 
 	public static final int MAX_EVAL = 1000000000;
 	public static final int MIN_EVAL = -1000000000;
@@ -22,7 +22,7 @@ public class AlphaBeta
 
 	public static final int MAX_PLY = 256;
 
-	private final int ASPIRATION_DELTA = 603;
+	private final int ASPIRATION_DELTA = 25;
 
 	private final TranspositionTable tt;
 
@@ -145,8 +145,7 @@ public class AlphaBeta
 				? NNUE.evaluate(network, accumulators.getWhiteAccumulator(), accumulators.getBlackAccumulator(),
 						NNUE.chooseOutputBucket(board))
 				: NNUE.evaluate(network, accumulators.getBlackAccumulator(), accumulators.getWhiteAccumulator(),
-						NNUE.chooseOutputBucket(board)))
-				* 24;
+						NNUE.chooseOutputBucket(board)));
 		return v;
 	}
 
@@ -237,7 +236,7 @@ public class AlphaBeta
 				return alpha;
 			}
 
-			futilityBase = standPat + 4932;
+			futilityBase = standPat + 205;
 			moves = board.pseudoLegalCaptures();
 			sortCaptures(moves, board);
 		}
@@ -361,7 +360,7 @@ public class AlphaBeta
 		}
 
 		if (!inSingularSearch && !isPV && !inCheck && depth < 7 && staticEval > beta
-				&& staticEval - depth * 1687 > beta)
+				&& staticEval - depth * 70 > beta)
 		{
 			return beta;
 		}
@@ -456,7 +455,7 @@ public class AlphaBeta
 							|| currentMoveEntry.getType().equals(TranspositionTable.NodeType.LOWERBOUND))
 					&& currentMoveEntry.getDepth() > depth - 2)
 			{
-				int singularBeta = currentMoveEntry.getEvaluation() - 72 * depth;
+				int singularBeta = currentMoveEntry.getEvaluation() - 3 * depth;
 				int singularDepth = depth / 2;
 				int moveCountBackup = ss.moveCount;
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
@@ -97,7 +97,7 @@ public class UCI
 		if (Math.abs(score) < AlphaBeta.MATE_EVAL - AlphaBeta.MAX_PLY)
 		{
 			System.out.printf("info depth %d seldepth %d nodes %d nps %d score cp %d time %d pv %s\n", depth, selDepth,
-					nodes, nodes * 1000L / Math.max(1, ms), score / PeSTO.MAX_PHASE, ms, String.join(" ", Arrays
+					nodes, nodes * 1000L / Math.max(1, ms), score, ms, String.join(" ", Arrays
 							.stream(pv).takeWhile(x -> x != null).map(Object::toString).collect(Collectors.toList())));
 		}
 


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 2.23 +/- 4.50, nElo: 3.32 +/- 6.71
LOS: 83.40 %, DrawRatio: 42.99 %, PairsRatio: 1.05
Games: 10300, Wins: 3173, Losses: 3107, Draws: 4020, Points: 5183.0 (50.32 %)
Ptnml(0-2): [283, 1151, 2214, 1221, 281]
LLR: 2.95 (-2.94, 2.94) [-5.00, 3.00]
