### PR TITLE
Introduce Verification Search in Null Move Pruning

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -34,6 +34,7 @@ public class AlphaBeta
 	private Move[][] pv;
 	private Move[][] counterMoves;
 	private History history;
+	private int nmpMinPly;
 
 	private int rootDepth;
 	private int selDepth;
@@ -379,7 +380,21 @@ public class AlphaBeta
 
 			if (nullEval >= beta && nullEval < MATE_EVAL - 1024)
 			{
-				return nullEval;
+				if (this.nmpMinPly != 0 || depth < 12)
+				{
+					return nullEval;
+				}
+				
+				this.nmpMinPly = ply + 3 * (depth - r) / 4;
+				
+				int v = mainSearch(board, depth - r, -beta, -beta + 1, ply + 1, false);
+				
+				this.nmpMinPly = 0;
+				
+				if (v > beta)
+				{
+					return nullEval;
+				}
 			}
 		}
 
@@ -594,6 +609,7 @@ public class AlphaBeta
 				board.getMoveCounter());
 		this.searchStack = newSearchStack();
 		this.accumulators = new AccumulatorManager(network, board);
+		this.nmpMinPly = 0;
 
 		try
 		{


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 3.56 +/- 5.48, nElo: 5.25 +/- 8.07
LOS: 89.89 %, DrawRatio: 41.65 %, PairsRatio: 1.06
Games: 7116, Wins: 2181, Losses: 2108, Draws: 2827, Points: 3594.5 (50.51 %)
Ptnml(0-2): [193, 816, 1482, 859, 208]
LLR: 2.95 (-2.94, 2.94) [-5.00, 3.00]