### PR TITLE
Gradually Widen Aspiration Window & Refactor Iterative Deepening

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Limits.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Limits.java
@@ -72,4 +72,9 @@ public class Limits
 	{
 		this.depth = depth;
 	}
+
+	public Limits clone()
+	{
+		return new Limits(time, increment, movesToGo, nodes, depth);
+	}
 }


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 8.70 +/- 6.40, nElo: 13.59 +/- 10.00
LOS: 99.61 %, DrawRatio: 43.87 %, PairsRatio: 1.18
Games: 4636, Wins: 1408, Losses: 1292, Draws: 1936, Points: 2376.0 (51.25 %)
Ptnml(0-2): [95, 503, 1017, 597, 106]
LLR: 2.95 (-2.94, 2.94) [0.00, 8.00]