### PR TITLE
Adjust LMP In Accordance to Static Eval Improvements

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -455,7 +455,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth / (improving ? 2 : 1)
+			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth
 					&& alpha > -MATE_EVAL + 1024)
 			{
 				continue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -14,8 +14,8 @@ public class AlphaBeta
 	private static final int BISHOP_VALUE = 365;
 	private static final int ROOK_VALUE = 477;
 	private static final int QUEEN_VALUE = 1025;
-	private static final int VALUE_NONE = 32002;
-
+	
+	public static final int VALUE_NONE = 32002;
 	public static final int MAX_EVAL = 1000000000;
 	public static final int MIN_EVAL = -1000000000;
 	public static final int MATE_EVAL = 500000000;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -471,7 +471,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > (3 + depth * depth) / (improving ? 1 : 2)
+			if (isQuiet && !isPV && !givesCheck && sse.moveCount > 3 + depth * depth / (improving ? 1 : 2)
 					&& alpha > -MATE_EVAL + 1024)
 			{
 				continue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -365,8 +365,8 @@ public class AlphaBeta
 		{
 			eval = sse.staticEval = evaluate(board);
 		}
-		
-		improving = ss.get(-2).staticEval != VALUE_NONE && ss.get(-2).staticEval < sse.staticEval;
+
+		improving = !inCheck && ss.get(-2).staticEval != VALUE_NONE && ss.get(-2).staticEval < sse.staticEval;
 
 		if (!inSingularSearch && !isPV && !inCheck && depth < 7 && eval > beta && eval - depth * 70 > beta)
 		{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -366,8 +366,24 @@ public class AlphaBeta
 			eval = sse.staticEval = evaluate(board);
 		}
 
-		improving = !inCheck && ((ss.get(-2).staticEval != VALUE_NONE ? (ss.get(-2).staticEval < sse.staticEval)
-				: (ss.get(-4).staticEval != VALUE_NONE && ss.get(-4).staticEval < sse.staticEval)));
+		improving = false;
+
+		if (!inCheck)
+		{
+			if (ss.get(-2).staticEval != VALUE_NONE)
+			{
+				improving = ss.get(-2).staticEval < sse.staticEval;
+			}
+
+			else if (ss.get(-4).staticEval != VALUE_NONE)
+			{
+				improving = ss.get(-4).staticEval < sse.staticEval;
+			}
+			else
+			{
+				improving = true;
+			}
+		}
 
 		if (!inSingularSearch && !isPV && !inCheck && depth < 7 && eval > beta && eval - depth * 70 > beta)
 		{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -471,7 +471,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth / (improving ? 1 : 2)
+			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > (3 + depth * depth) / (improving ? 1 : 2)
 					&& alpha > -MATE_EVAL + 1024)
 			{
 				continue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -14,7 +14,7 @@ public class AlphaBeta
 	private static final int BISHOP_VALUE = 365;
 	private static final int ROOK_VALUE = 477;
 	private static final int QUEEN_VALUE = 1025;
-	
+
 	public static final int VALUE_NONE = 32002;
 	public static final int MAX_EVAL = 1000000000;
 	public static final int MIN_EVAL = -1000000000;
@@ -366,7 +366,8 @@ public class AlphaBeta
 			eval = sse.staticEval = evaluate(board);
 		}
 
-		improving = !inCheck && ss.get(-2).staticEval != VALUE_NONE && ss.get(-2).staticEval < sse.staticEval;
+		improving = !inCheck && (ss.get(-2).staticEval != VALUE_NONE ? (ss.get(-2).staticEval < sse.staticEval)
+				: (ss.get(-4).staticEval != VALUE_NONE && ss.get(-4).staticEval < sse.staticEval));
 
 		if (!inSingularSearch && !isPV && !inCheck && depth < 7 && eval > beta && eval - depth * 70 > beta)
 		{

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -366,8 +366,8 @@ public class AlphaBeta
 			eval = sse.staticEval = evaluate(board);
 		}
 
-		improving = !inCheck && (ss.get(-2).staticEval != VALUE_NONE ? (ss.get(-2).staticEval < sse.staticEval)
-				: (ss.get(-4).staticEval != VALUE_NONE && ss.get(-4).staticEval < sse.staticEval));
+		improving = !inCheck && ((ss.get(-2).staticEval != VALUE_NONE ? (ss.get(-2).staticEval < sse.staticEval)
+				: (ss.get(-4).staticEval != VALUE_NONE && ss.get(-4).staticEval < sse.staticEval)));
 
 		if (!inSingularSearch && !isPV && !inCheck && depth < 7 && eval > beta && eval - depth * 70 > beta)
 		{
@@ -455,7 +455,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth
+			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth / (improving ? 1 : 2)
 					&& alpha > -MATE_EVAL + 1024)
 			{
 				continue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -455,7 +455,7 @@ public class AlphaBeta
 					&& !(PieceType.PAWN.equals(board.getPiece(move.getFrom()).getPieceType())
 							&& move.getTo() == board.getEnPassant());
 
-			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth / (improving ? 1 : 2)
+			if (isQuiet && !isPV && !givesCheck && depth <= 6 && sse.moveCount > 3 + depth * depth / (improving ? 2 : 1)
 					&& alpha > -MATE_EVAL + 1024)
 			{
 				continue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
@@ -9,7 +9,7 @@ public class SearchStack
 		public boolean inCheck;
 		public boolean ttHit;
 		public int moveCount;
-		public int staticEval;
+		public int staticEval = AlphaBeta.VALUE_NONE;
 		public Move killer;
 		public Move excludedMove;
 	}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
@@ -28,6 +28,6 @@ public class SearchStack
 	
 	public SearchState get(int index)
 	{
-		return stack[index + 2];
+		return stack[index + 5];
 	}
 }

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
@@ -9,6 +9,7 @@ public class SearchStack
 		public boolean inCheck;
 		public boolean ttHit;
 		public int moveCount;
+		public int staticEval;
 		public Move killer;
 		public Move excludedMove;
 	}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/SearchStack.java
@@ -18,7 +18,7 @@ public class SearchStack
 	
 	public SearchStack(int n)
 	{
-		stack = new SearchState[n + 3];
+		stack = new SearchState[n + 5];
 		
 		for (int i = 0; i < stack.length;i ++)
 		{


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 6.45 +/- 4.52, nElo: 9.93 +/- 6.95
LOS: 99.74 %, DrawRatio: 44.10 %, PairsRatio: 1.11
Games: 9592, Wins: 2919, Losses: 2741, Draws: 3932, Points: 4885.0 (50.93 %)
Ptnml(0-2): [212, 1056, 2115, 1168, 245]
LLR: 2.95 (-2.94, 2.94) [0.00, 5.00]
