### PR TITLE
Fix eval and staticEval

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -363,7 +363,7 @@ public class AlphaBeta
 			eval = sse.staticEval = currentMoveEntry.getStaticEval();
 
 			if (currentMoveEntry
-					.getType() != (currentMoveEntry.getEvaluation() > eval ? NodeType.LOWERBOUND : NodeType.UPPERBOUND))
+					.getType() != (currentMoveEntry.getEvaluation() > eval ? NodeType.UPPERBOUND : NodeType.LOWERBOUND))
 			{
 				eval = currentMoveEntry.getEvaluation();
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -360,7 +360,7 @@ public class AlphaBeta
 		}
 		else
 		{
-			sse.staticEval = evaluate(board);
+			eval = sse.staticEval = evaluate(board);
 		}
 
 		improving = false;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -360,10 +360,10 @@ public class AlphaBeta
 		}
 		else
 		{
-			sse.staticEval = evaluate(board);
 
 			if (currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
 			{
+				sse.staticEval = currentMoveEntry.getStaticEval();
 				eval = currentMoveEntry.getEvaluation();
 				switch (currentMoveEntry.getType())
 				{
@@ -387,7 +387,7 @@ public class AlphaBeta
 			}
 			else
 			{
-				eval = sse.staticEval;
+				eval = sse.staticEval = evaluate(board);
 			}
 		}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -370,15 +370,15 @@ public class AlphaBeta
 					case EXACT:
 						break;
 					case UPPERBOUND:
-						if (eval < sse.staticEval)
+						if (eval > sse.staticEval)
 						{
-							return eval;
+							eval = sse.staticEval;
 						}
 						break;
 					case LOWERBOUND:
-						if (eval > sse.staticEval)
+						if (eval < sse.staticEval)
 						{
-							return eval;
+							eval = sse.staticEval;
 						}
 						break;
 					default:

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -358,19 +358,9 @@ public class AlphaBeta
 		{
 			eval = sse.staticEval = VALUE_NONE;
 		}
-		else if (currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
-		{
-			eval = sse.staticEval = currentMoveEntry.getStaticEval();
-
-			if (currentMoveEntry
-					.getType() != (currentMoveEntry.getEvaluation() > eval ? NodeType.UPPERBOUND : NodeType.LOWERBOUND))
-			{
-				eval = currentMoveEntry.getEvaluation();
-			}
-		}
 		else
 		{
-			eval = sse.staticEval = evaluate(board);
+			sse.staticEval = evaluate(board);
 		}
 
 		improving = false;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -2,6 +2,7 @@ package org.shawn.games.Serendipity;
 
 import java.util.*;
 
+import org.shawn.games.Serendipity.TranspositionTable.NodeType;
 import org.shawn.games.Serendipity.NNUE.*;
 
 import com.github.bhlangonijr.chesslib.*;
@@ -359,7 +360,13 @@ public class AlphaBeta
 		}
 		else if (currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
 		{
-			eval = sse.staticEval = currentMoveEntry.getEvaluation();
+			eval = sse.staticEval = currentMoveEntry.getStaticEval();
+
+			if (currentMoveEntry
+					.getType() != (currentMoveEntry.getEvaluation() > eval ? NodeType.LOWERBOUND : NodeType.UPPERBOUND))
+			{
+				eval = currentMoveEntry.getEvaluation();
+			}
 		}
 		else
 		{
@@ -565,7 +572,7 @@ public class AlphaBeta
 				if (alpha >= beta)
 				{
 					tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.LOWERBOUND, depth, bestValue,
-							bestMove);
+							bestMove, sse.staticEval);
 
 					for (Move quietMove : quietMovesFailBeta)
 					{
@@ -602,12 +609,14 @@ public class AlphaBeta
 
 		if (alpha == oldAlpha)
 		{
-			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, ttMove);
+			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.UPPERBOUND, depth, bestValue, ttMove,
+					sse.staticEval);
 		}
 
 		else if (alpha > oldAlpha)
 		{
-			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.EXACT, depth, bestValue, bestMove);
+			tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.EXACT, depth, bestValue, bestMove,
+					sse.staticEval);
 		}
 
 		return bestValue;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -360,7 +360,35 @@ public class AlphaBeta
 		}
 		else
 		{
-			eval = sse.staticEval = evaluate(board);
+			sse.staticEval = evaluate(board);
+
+			if (currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
+			{
+				eval = currentMoveEntry.getEvaluation();
+				switch (currentMoveEntry.getType())
+				{
+					case EXACT:
+						break;
+					case UPPERBOUND:
+						if (eval < sse.staticEval)
+						{
+							return eval;
+						}
+						break;
+					case LOWERBOUND:
+						if (eval > sse.staticEval)
+						{
+							return eval;
+						}
+						break;
+					default:
+						throw new IllegalArgumentException("Unexpected value: " + currentMoveEntry.getType());
+				}
+			}
+			else
+			{
+				eval = sse.staticEval;
+			}
 		}
 
 		improving = false;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -15,17 +15,19 @@ public class TranspositionTable
 	{
 		private long signature;
 		private NodeType type;
-		private int depth;
+		private short depth;
 		private int evaluation;
+		private int staticEval;
 		private Move move;
 
-		public Entry(NodeType type, int depth, int evaluation, long signature, Move move)
+		public Entry(NodeType type, short depth, int evaluation, long signature, Move move, int staticEval)
 		{
 			this.signature = signature;
 			this.type = type;
 			this.depth = depth;
 			this.evaluation = evaluation;
 			this.move = move;
+			this.staticEval = staticEval;
 		}
 
 		public long getSignature()
@@ -38,7 +40,7 @@ public class TranspositionTable
 			return type;
 		}
 
-		public int getDepth()
+		public short getDepth()
 		{
 			return depth;
 		}
@@ -48,6 +50,11 @@ public class TranspositionTable
 			return evaluation;
 		}
 		
+		public int getStaticEval()
+		{
+			return staticEval;
+		}
+
 		public Move getMove()
 		{
 			return move;
@@ -70,9 +77,9 @@ public class TranspositionTable
 		return entries[(int) (hash & mask)];
 	}
 
-	public void write(long hash, NodeType type, int depth, int evaluation, Move move)
+	public void write(long hash, NodeType type, int depth, int evaluation, Move move, int staticEval)
 	{
-		entries[(int) (hash & mask)] = new Entry(type, depth, evaluation, hash, move);
+		entries[(int) (hash & mask)] = new Entry(type, (short) depth, evaluation, hash, move, staticEval);
 	}
 
 	public void clear()

--- a/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
+++ b/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
@@ -14,7 +14,7 @@ public class TranspositionTableTest
 	{
 		Board board = new Board();
 		TranspositionTable tt = new TranspositionTable(128);
-		tt.write(board.getIncrementalHashKey(), NodeType.EXACT, 12, 2, null);
+		tt.write(board.getIncrementalHashKey(), NodeType.EXACT, 12, 2, null, 0);
 		assertTrue(tt.probe(board.getIncrementalHashKey()).getDepth() == 12);
 		assertTrue(tt.probe(board.getIncrementalHashKey()).getEvaluation() == 2);
 		assertTrue(tt.probe(board.getIncrementalHashKey()).getSignature() == board.getIncrementalHashKey());


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 2.29 +/- 4.40, nElo: 3.60 +/- 6.91
LOS: 84.61 %, DrawRatio: 44.94 %, PairsRatio: 1.03
Games: 9716, Wins: 2859, Losses: 2795, Draws: 4062, Points: 4890.0 (50.33 %)
Ptnml(0-2): [198, 1120, 2183, 1134, 223]
LLR: 2.96 (-2.94, 2.94) [-5.00, 3.00]