### PR TITLE
Adjust NMP Reduction With Eval Beta Difference

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -421,7 +421,7 @@ public class AlphaBeta
 								.getBitboard(board.getSideToMove())
 				&& eval >= beta && ply > 0)
 		{
-			int r = depth / 3 + 4;
+			int r = depth / 3 + 4 + Math.min((eval - beta) / 200, 3);
 
 			board.doNullMove();
 			int nullEval = -mainSearch(board, depth - r, -beta, -beta + 1, ply + 1, false);


### PR DESCRIPTION
Results of Serendipity-Test vs Serendipity-Stable:
Elo: 5.40 +/- 4.34, nElo: 8.82 +/- 7.08
LOS: 99.27 %, DrawRatio: 45.53 %, PairsRatio: 1.11
Games: 9260, Wins: 2607, Losses: 2463, Draws: 4190, Points: 4702.0 (50.78 %)
Ptnml(0-2): [153, 1043, 2108, 1159, 167]
LLR: 2.96 (-2.94, 2.94) [0.00, 8.00]