### PR TITLE
Make TT More Compact

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -130,7 +130,7 @@ public class AlphaBeta
 						NNUE.chooseOutputBucket(board))
 				: NNUE.evaluate(network, accumulators.getBlackAccumulator(), accumulators.getWhiteAccumulator(),
 						NNUE.chooseOutputBucket(board)));
-		
+
 		return v;
 	}
 
@@ -175,7 +175,7 @@ public class AlphaBeta
 
 		TranspositionTable.Entry currentMoveEntry = tt.probe(board.getIncrementalHashKey());
 
-		if (!isPV && currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
+		if (!isPV && currentMoveEntry != null && currentMoveEntry.verifySignature(board.getIncrementalHashKey()))
 		{
 			int eval = currentMoveEntry.getEvaluation();
 			switch (currentMoveEntry.getType())
@@ -331,7 +331,7 @@ public class AlphaBeta
 		sse.ttHit = currentMoveEntry != null;
 
 		if (!inSingularSearch && !isPV && currentMoveEntry != null && currentMoveEntry.getDepth() >= depth
-				&& currentMoveEntry.getSignature() == board.getIncrementalHashKey())
+				&& currentMoveEntry.verifySignature(board.getIncrementalHashKey()))
 		{
 			eval = currentMoveEntry.getEvaluation();
 			switch (currentMoveEntry.getType())
@@ -362,7 +362,7 @@ public class AlphaBeta
 		else
 		{
 
-			if (currentMoveEntry != null && currentMoveEntry.getSignature() == board.getIncrementalHashKey())
+			if (currentMoveEntry != null && currentMoveEntry.verifySignature(board.getIncrementalHashKey()))
 			{
 				sse.staticEval = currentMoveEntry.getStaticEval();
 				eval = currentMoveEntry.getEvaluation();

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -16,10 +16,10 @@ public class AlphaBeta
 	private static final int ROOK_VALUE = 477;
 	private static final int QUEEN_VALUE = 1025;
 
-	public static final int VALUE_NONE = 32002;
-	public static final int MAX_EVAL = 1000000000;
-	public static final int MIN_EVAL = -1000000000;
-	public static final int MATE_EVAL = 500000000;
+	public static final int VALUE_NONE = 30002;
+	public static final int MAX_EVAL = 32767;
+	public static final int MIN_EVAL = -32767;
+	public static final int MATE_EVAL = 32700;
 	public static final int DRAW_EVAL = 0;
 
 	public static final int MAX_PLY = 256;
@@ -130,6 +130,7 @@ public class AlphaBeta
 						NNUE.chooseOutputBucket(board))
 				: NNUE.evaluate(network, accumulators.getBlackAccumulator(), accumulators.getWhiteAccumulator(),
 						NNUE.chooseOutputBucket(board)));
+		
 		return v;
 	}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -20,9 +20,9 @@ public class TranspositionTable
 		// evaluation: 16 bits
 		// staticEval: 16 bits
 		// Square: 64 bits
-		//
+		// Signature: 16 bits
 
-		private long signature;
+		private short signature16;
 		private short depthAndType;
 		private short evaluation;
 		private short staticEval;
@@ -30,7 +30,7 @@ public class TranspositionTable
 
 		public Entry(NodeType type, short depth, int evaluation, long signature, Move move, int staticEval)
 		{
-			this.signature = signature;
+			this.signature16 = (short) (signature >> 48);
 			this.depthAndType = (short) ((depth << 2) + typeToByte(type));
 			this.move = (move == null) ? 0 : (short) ((move.getFrom().ordinal() << 6) + move.getTo().ordinal());
 			this.evaluation = (short) evaluation;
@@ -47,9 +47,14 @@ public class TranspositionTable
 			};
 		}
 
-		public long getSignature()
+		public short getSignature()
 		{
-			return signature;
+			return signature16;
+		}
+
+		public boolean verifySignature(long signature)
+		{
+			return signature >> 48 == signature16;
 		}
 
 		public NodeType getType()
@@ -80,8 +85,9 @@ public class TranspositionTable
 
 		public Move getMove()
 		{
-			//System.out.print(this.originalMove + " " + this.originalMove != null ? 0 : this.originalMove.getTo().ordinal() + " ");
-			//System.out.println(Integer.toBinaryString(this.move));
+			// System.out.print(this.originalMove + " " + this.originalMove != null ? 0 :
+			// this.originalMove.getTo().ordinal() + " ");
+			// System.out.println(Integer.toBinaryString(this.move));
 			return move == 0 ? null : new Move(Square.squareAt(move >> 6), Square.squareAt(move & 0b111111));
 		}
 	}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -19,7 +19,7 @@ public class TranspositionTable
 		// NodeType: 2 bits
 		// evaluation: 16 bits
 		// staticEval: 16 bits
-		// Square: 64 bits
+		// Square: 6 bits
 		// Signature: 16 bits
 
 		private short signature16;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -20,9 +20,9 @@ public class TranspositionTable
 		// evaluation: 16 bits
 		// staticEval: 16 bits
 		// Square: 6 bits
-		// Signature: 16 bits
+		// Signature: 64 bits
 
-		private short signature16;
+		private long signature;
 		private short depthAndType;
 		private short evaluation;
 		private short staticEval;
@@ -30,7 +30,7 @@ public class TranspositionTable
 
 		public Entry(NodeType type, short depth, int evaluation, long signature, Move move, int staticEval)
 		{
-			this.signature16 = (short) (signature >> 48);
+			this.signature = signature;
 			this.depthAndType = (short) ((depth << 2) + typeToByte(type));
 			this.move = (move == null) ? 0 : (short) ((move.getFrom().ordinal() << 6) + move.getTo().ordinal());
 			this.evaluation = (short) evaluation;
@@ -47,14 +47,14 @@ public class TranspositionTable
 			};
 		}
 
-		public short getSignature()
+		public long getSignature()
 		{
-			return signature16;
+			return signature;
 		}
 
 		public boolean verifySignature(long signature)
 		{
-			return signature >> 48 == signature16;
+			return signature == this.signature;
 		}
 
 		public NodeType getType()

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -14,7 +14,6 @@ public class TranspositionTable
 
 	public class Entry
 	{
-
 		// depth: (0-255) 8 bits
 		// NodeType: 2 bits
 		// evaluation: 16 bits

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TranspositionTable.java
@@ -2,6 +2,7 @@ package org.shawn.games.Serendipity;
 
 import java.util.Arrays;
 
+import com.github.bhlangonijr.chesslib.Square;
 import com.github.bhlangonijr.chesslib.move.*;
 
 public class TranspositionTable
@@ -13,21 +14,37 @@ public class TranspositionTable
 
 	public class Entry
 	{
+
+		// depth: (0-255) 8 bits
+		// NodeType: 2 bits
+		// evaluation: 16 bits
+		// staticEval: 16 bits
+		// Square: 64 bits
+		//
+
 		private long signature;
-		private NodeType type;
-		private short depth;
-		private int evaluation;
-		private int staticEval;
-		private Move move;
+		private short depthAndType;
+		private short evaluation;
+		private short staticEval;
+		private short move;
 
 		public Entry(NodeType type, short depth, int evaluation, long signature, Move move, int staticEval)
 		{
 			this.signature = signature;
-			this.type = type;
-			this.depth = depth;
-			this.evaluation = evaluation;
-			this.move = move;
-			this.staticEval = staticEval;
+			this.depthAndType = (short) ((depth << 2) + typeToByte(type));
+			this.move = (move == null) ? 0 : (short) ((move.getFrom().ordinal() << 6) + move.getTo().ordinal());
+			this.evaluation = (short) evaluation;
+			this.staticEval = (short) staticEval;
+		}
+
+		private byte typeToByte(NodeType type)
+		{
+			return switch (type)
+			{
+				case EXACT -> 0;
+				case LOWERBOUND -> 1;
+				case UPPERBOUND -> 2;
+			};
 		}
 
 		public long getSignature()
@@ -37,19 +54,25 @@ public class TranspositionTable
 
 		public NodeType getType()
 		{
-			return type;
+			return switch (this.depthAndType & 0b11)
+			{
+				case 0 -> NodeType.EXACT;
+				case 1 -> NodeType.LOWERBOUND;
+				case 2 -> NodeType.UPPERBOUND;
+				default -> throw new IllegalArgumentException("Unexpected value: " + (this.depthAndType & 0b11));
+			};
 		}
 
 		public short getDepth()
 		{
-			return depth;
+			return (short) (depthAndType >> 2);
 		}
 
 		public int getEvaluation()
 		{
 			return evaluation;
 		}
-		
+
 		public int getStaticEval()
 		{
 			return staticEval;
@@ -57,7 +80,9 @@ public class TranspositionTable
 
 		public Move getMove()
 		{
-			return move;
+			//System.out.print(this.originalMove + " " + this.originalMove != null ? 0 : this.originalMove.getTo().ordinal() + " ");
+			//System.out.println(Integer.toBinaryString(this.move));
+			return move == 0 ? null : new Move(Square.squareAt(move >> 6), Square.squareAt(move & 0b111111));
 		}
 	}
 

--- a/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
+++ b/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
@@ -17,6 +17,6 @@ public class TranspositionTableTest
 		tt.write(board.getIncrementalHashKey(), NodeType.EXACT, 12, 2, null, 0);
 		assertTrue(tt.probe(board.getIncrementalHashKey()).getDepth() == 12);
 		assertTrue(tt.probe(board.getIncrementalHashKey()).getEvaluation() == 2);
-		assertTrue(tt.probe(board.getIncrementalHashKey()).getSignature() == board.getIncrementalHashKey());
+		assertTrue(tt.probe(board.getIncrementalHashKey()).verifySignature(board.getIncrementalHashKey()));
 	}
 }


### PR DESCRIPTION
Object Layout:
```
org.shawn.games.Serendipity.TranspositionTable$Entry object internals:
 OFFSET  SIZE                                             TYPE DESCRIPTION                               VALUE
      0    12                                                  (object header)                           N/A
     12     2                                            short Entry.depthAndType                        N/A
     14     2                                            short Entry.evaluation                          N/A
     16     8                                             long Entry.signature                           N/A
     24     2                                            short Entry.staticEval                          N/A
     26     2                                            short Entry.move                                N/A
     28     4   org.shawn.games.Serendipity.TranspositionTable Entry.this$0                              N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```
Passed Non-reg:
```
Elo   | 1.78 +- 12.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.08 (-2.94, 2.94) [-20.00, 10.00]
Games | N: 1562 W: 441 L: 433 D: 688
Penta | [31, 169, 367, 189, 25]
https://chess.aronpetkovski.com/test/152/
```