### PR TITLE
Functional Speedup in Qsearch Movesort

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -85,32 +85,7 @@ public class AlphaBeta
 			return 0;
 		}
 
-		if (p.getPieceType().equals(PieceType.PAWN))
-		{
-			return PAWN_VALUE;
-		}
-
-		if (p.getPieceType().equals(PieceType.KNIGHT))
-		{
-			return KNIGHT_VALUE;
-		}
-
-		if (p.getPieceType().equals(PieceType.BISHOP))
-		{
-			return BISHOP_VALUE;
-		}
-
-		if (p.getPieceType().equals(PieceType.ROOK))
-		{
-			return ROOK_VALUE;
-		}
-
-		if (p.getPieceType().equals(PieceType.QUEEN))
-		{
-			return QUEEN_VALUE;
-		}
-
-		return 0;
+		return p.getPieceType().ordinal();
 	}
 
 	private int stat_bonus(int depth)
@@ -149,8 +124,8 @@ public class AlphaBeta
 			@Override
 			public int compare(Move m1, Move m2)
 			{
-				return pieceValue(board.getPiece(m2.getTo())) - pieceValue(board.getPiece(m2.getFrom()))
-						- (pieceValue(board.getPiece(m1.getTo())) - pieceValue(board.getPiece(m1.getFrom())));
+				return pieceValue(board.getPiece(m2.getTo())) * 100 - pieceValue(board.getPiece(m2.getFrom()))
+						- (pieceValue(board.getPiece(m1.getTo())) * 100 - pieceValue(board.getPiece(m1.getFrom())));
 			}
 
 		});


### PR DESCRIPTION
Elo   | 11.45 +- 10.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [-5.00, 3.00]
Games | N: 2306 W: 684 L: 608 D: 1014
Penta | [31, 246, 536, 296, 44]
https://chess.aronpetkovski.com/test/234/

bench 985023