### PR TITLE
Use Alexandria's Soft TM

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TimeManager.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TimeManager.java
@@ -15,29 +15,44 @@ public class TimeManager
 
 	public TimeManager(long timeLeft, long increment, int movesToGo, long moveOverHead, int moves)
 	{
-		this.timeLeft = timeLeft;
+		if (timeLeft < 0)
+		{
+			timeLeft = 1000;
+		}
+
+		this.timeLeft = timeLeft - Math.min(moveOverHead, timeLeft) / 2;
 		this.increment = increment;
 		this.moveOverHead = moveOverHead;
 
-		if (movesToGo == 0)
+		if (movesToGo != 0)
 		{
-			movesToGo = 20;
+			this.movesToGo = movesToGo;
+
+			this.hardLimit = this.timeLeft / this.movesToGo + this.increment * 3 / 4;
+			this.softLimit = this.hardLimit / 2;
+
+			this.startTime = System.nanoTime();
+			this.hardLimitTimeStamp = startTime + 1000000L * this.hardLimit;
+			this.softLimitTimeStamp = startTime + 1000000L * this.softLimit;
+
+			return;
 		}
 
-		if (movesToGo == -1)
+		else if (movesToGo == -1)
 		{
 			this.hardLimit = this.softLimit = this.timeLeft;
 
 			this.startTime = System.nanoTime();
 			this.hardLimitTimeStamp = this.softLimitTimeStamp = startTime + 1000000L * this.timeLeft;
-			
+
 			return;
 		}
 
-		this.movesToGo = movesToGo;
+		int baseTime = (int) (this.timeLeft * 0.054 + this.increment * 0.85);
+		int maxTime = (int) (this.timeLeft * 0.76);
 
-		this.hardLimit = this.timeLeft / this.movesToGo + this.increment * 3 / 4 - this.moveOverHead;
-		this.softLimit = this.hardLimit / 2;
+		this.hardLimit = Math.min(maxTime, (int) (baseTime * 3.04));
+		this.softLimit = Math.min(maxTime, (int) (baseTime * 0.76));
 
 		this.startTime = System.nanoTime();
 		this.hardLimitTimeStamp = startTime + 1000000L * this.hardLimit;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/TimeManager.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/TimeManager.java
@@ -24,10 +24,20 @@ public class TimeManager
 			movesToGo = 20;
 		}
 
+		if (movesToGo == -1)
+		{
+			this.hardLimit = this.softLimit = this.timeLeft;
+
+			this.startTime = System.nanoTime();
+			this.hardLimitTimeStamp = this.softLimitTimeStamp = startTime + 1000000L * this.timeLeft;
+			
+			return;
+		}
+
 		this.movesToGo = movesToGo;
 
 		this.hardLimit = this.timeLeft / this.movesToGo + this.increment * 3 / 4 - this.moveOverHead;
-		this.softLimit = this.movesToGo != 1 ? this.hardLimit / 2 : this.hardLimit;
+		this.softLimit = this.hardLimit / 2;
 
 		this.startTime = System.nanoTime();
 		this.hardLimitTimeStamp = startTime + 1000000L * this.hardLimit;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
@@ -260,7 +260,7 @@ public class UCI
 						{
 							limits.setTime(Long.parseLong(fullCommand[i + 1]));
 							limits.setIncrement(0);
-							limits.setMovesToGo(1);
+							limits.setMovesToGo(-1);
 						}
 
 						if (fullCommand[i].equals("movestogo"))


### PR DESCRIPTION
Old time management was not tested at a proper time control. This patch replaces the soft time limit algorithm with one from Alexandria.

Passed STC:
Elo   | 95.48 +- 22.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 608 W: 265 L: 102 D: 241
Penta | [3, 31, 110, 120, 40]
https://chess.aronpetkovski.com/test/400/

Passed LTC:
Elo   | 38.33 +- 18.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 8.00]
Games | N: 728 W: 224 L: 144 D: 360
Penta | [4, 55, 175, 117, 13]
https://chess.aronpetkovski.com/test/410/

Cyclic Fix Passed Non-regression STC:
Elo   | 0.73 +- 3.79 (95%)
SPRT  | 40/4.0+0.00s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 19958 W: 6214 L: 6172 D: 7572
Penta | [480, 2108, 4759, 2154, 478]
https://chess.aronpetkovski.com/test/399/