### PR TITLE
SE Tweaks

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -511,6 +511,11 @@ public class AlphaBeta
 						extension = 2;
 					}
 				}
+				
+				else if (singularValue > beta)
+				{
+					return singularValue;
+				}
 
 			}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -487,13 +487,13 @@ public class AlphaBeta
 
 			int extension = 0;
 
-			if (!inSingularSearch && ply > 0 && move.equals(ttMove) && depth > 8
+			if (!inSingularSearch && ply > 0 && move.equals(ttMove) && depth >= 8
 					&& Math.abs(currentMoveEntry.getEvaluation()) < MATE_EVAL - 1024
 					&& (currentMoveEntry.getType().equals(TranspositionTable.NodeType.EXACT)
 							|| currentMoveEntry.getType().equals(TranspositionTable.NodeType.LOWERBOUND))
-					&& currentMoveEntry.getDepth() > depth - 2)
+					&& currentMoveEntry.getDepth() > depth - 4)
 			{
-				int singularBeta = currentMoveEntry.getEvaluation() - 3 * depth;
+				int singularBeta = currentMoveEntry.getEvaluation() - 2 * depth;
 				int singularDepth = depth / 2;
 				int moveCountBackup = sse.moveCount;
 
@@ -504,7 +504,7 @@ public class AlphaBeta
 
 				if (singularValue < singularBeta)
 				{
-					extension = 2;
+					extension = 1;
 				}
 
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -505,6 +505,11 @@ public class AlphaBeta
 				if (singularValue < singularBeta)
 				{
 					extension = 1;
+					
+					if (!isPV)
+					{
+						extension = 2;
+					}
 				}
 
 			}


### PR DESCRIPTION
Unclear Scaling Behavior. Merging this since it shouldn't regress at high TC.

Elo   | 12.00 +- 8.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 10.00]
Games | N: 2114 W: 567 L: 494 D: 1053
Penta | [11, 229, 524, 262, 31]
https://chess.aronpetkovski.com/test/1164/

Elo   | 15.72 +- 9.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 10.00]
Games | N: 1548 W: 465 L: 395 D: 688
Penta | [12, 154, 381, 206, 21]
https://chess.aronpetkovski.com/test/1163/

Additional Tests Done Separately:

Elo   | 3.19 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25160 W: 6906 L: 6675 D: 11579
Penta | [343, 2938, 5813, 3117, 369]
https://chess.aronpetkovski.com/test/1130/

Elo   | 3.66 +- 2.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 8.00]
Games | N: 20056 W: 5430 L: 5219 D: 9407
Penta | [250, 2317, 4711, 2472, 278]
https://chess.aronpetkovski.com/test/1092/

Elo   | 5.16 +- 4.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 8.00]
Games | N: 7818 W: 2002 L: 1886 D: 3930
Penta | [29, 894, 1975, 954, 57]
https://chess.aronpetkovski.com/test/1064/

Elo   | 7.23 +- 5.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 8.00]
Games | N: 5578 W: 1531 L: 1415 D: 2632
Penta | [71, 628, 1289, 716, 85]
https://chess.aronpetkovski.com/test/1058/

bench 956814