### PR TITLE
Do More Singular Extensions

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -487,7 +487,7 @@ public class AlphaBeta
 
 			int extension = 0;
 
-			if (!inSingularSearch && ply > 0 && move.equals(ttMove) && depth >= 8
+			if (!inSingularSearch && ply > 0 && move.equals(ttMove) && depth >= 4
 					&& Math.abs(currentMoveEntry.getEvaluation()) < MATE_EVAL - 1024
 					&& (currentMoveEntry.getType().equals(TranspositionTable.NodeType.EXACT)
 							|| currentMoveEntry.getType().equals(TranspositionTable.NodeType.LOWERBOUND))


### PR DESCRIPTION
Lowers singular extension depth margin from 8 to 4.

Failed STC:
Elo   | -0.86 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18148 W: 4907 L: 4952 D: 8289
Penta | [285, 2203, 4108, 2228, 250]
https://chess.aronpetkovski.com/test/1176/

Passed LTC:
Elo   | 6.24 +- 4.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7846 W: 2003 L: 1862 D: 3981
Penta | [54, 879, 1916, 1020, 54]
https://chess.aronpetkovski.com/test/1189/

bench 2163951