### PR TITLE
Add WDL output and Normalize Eval

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -23,7 +23,7 @@ public class AlphaBeta
 	public static final int DRAW_EVAL = 0;
 
 	public static final int MAX_PLY = 256;
-	
+
 	public static final int[][] reduction = new int[256][256];
 
 	private final TranspositionTable tt;
@@ -69,10 +69,10 @@ public class AlphaBeta
 		this.ss = new SearchStack(MAX_PLY);
 
 		this.network = network;
-		
-		for (int i = 0; i < reduction.length; i ++)
+
+		for (int i = 0; i < reduction.length; i++)
 		{
-			for (int j = 0; j < reduction[0].length; j ++)
+			for (int j = 0; j < reduction[0].length; j++)
 			{
 				reduction[i][j] = (int) (1.60 + Math.log(i) * Math.log(j) / 2.17);
 			}
@@ -515,13 +515,13 @@ public class AlphaBeta
 				if (singularValue < singularBeta)
 				{
 					extension = 1;
-					
+
 					if (!isPV)
 					{
 						extension = 2;
 					}
 				}
-				
+
 				else if (singularValue > beta)
 				{
 					return singularValue;
@@ -689,7 +689,7 @@ public class AlphaBeta
 						if (!suppressOutput)
 						{
 							UCI.report(i, selDepth, nodesCount, currentScore, timeManager.timePassed(),
-									this.lastCompletePV);
+									this.internalBoard, this.lastCompletePV);
 						}
 						break;
 					}
@@ -760,10 +760,10 @@ public class AlphaBeta
 		this.captureHistory = new CaptureHistory();
 		this.rootDepth = 0;
 		this.selDepth = 0;
-		
-		for (int i = 0; i < reduction.length; i ++)
+
+		for (int i = 0; i < reduction.length; i++)
 		{
-			for (int j = 0; j < reduction[0].length; j ++)
+			for (int j = 0; j < reduction[0].length; j++)
 			{
 				reduction[i][j] = (int) (1.60 + Math.log(i) * Math.log(j) / 2.17);
 			}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI.java
@@ -92,22 +92,38 @@ public class UCI
 		myOption.set(value);
 	}
 
-	public static void report(int depth, int selDepth, int nodes, int score, long ms, Move[] pv)
+	public static void report(int depth, int selDepth, int nodes, int score, long ms, Board board, Move[] pv)
 	{
+		String pvString = String.join(" ",
+				Arrays.stream(pv).takeWhile(x -> x != null).map(Object::toString).collect(Collectors.toList()));
+
 		if (Math.abs(score) < AlphaBeta.MATE_EVAL - AlphaBeta.MAX_PLY)
 		{
-			System.out.printf("info depth %d seldepth %d nodes %d nps %d score cp %d time %d pv %s\n", depth, selDepth,
-					nodes, nodes * 1000L / Math.max(1, ms), score, ms, String.join(" ", Arrays.stream(pv)
-							.takeWhile(x -> x != null).map(Object::toString).collect(Collectors.toList())));
+			int cp = WDLModel.normalizeEval(score, board);
+			int[] wdl = WDLModel.calculateWDL(score, board);
+
+			System.out.printf("info depth %d seldepth %d nodes %d nps %d score cp %d wdl %d %d %d time %d pv %s\n",
+					depth, selDepth, nodes, nodes * 1000L / Math.max(1, ms), cp, wdl[0], wdl[1], wdl[2], ms, pvString);
 		}
 
 		else
 		{
 			int mateInPly = AlphaBeta.MATE_EVAL - Math.abs(score);
-			System.out.printf("info depth %d seldepth %d nodes %d nps %d score mate %d time %d pv %s\n", depth,
-					selDepth, nodes, nodes * 1000L / Math.max(1, ms),
-					mateInPly % 2 != 0 ? (mateInPly + 1) / 2 : -mateInPly / 2, ms, String.join(" ", Arrays.stream(pv)
-							.takeWhile(x -> x != null).map(Object::toString).collect(Collectors.toList())));
+			int mateValue = mateInPly % 2 != 0 ? (mateInPly + 1) / 2 : -mateInPly / 2;
+			int[] wdl;
+
+			if (mateValue < 0)
+			{
+				wdl = new int[] { 0, 0, 1000 };
+			}
+			else
+			{
+				wdl = new int[] { 1000, 0, 0 };
+			}
+
+			System.out.printf("info depth %d seldepth %d nodes %d nps %d score mate %d wdl %d %d %d time %d pv %s\n",
+					depth, selDepth, nodes, nodes * 1000L / Math.max(1, ms), mateValue, wdl[0], wdl[1], wdl[2], ms,
+					pvString);
 		}
 	}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
@@ -1,0 +1,71 @@
+package org.shawn.games.Serendipity;
+
+import com.github.bhlangonijr.chesslib.Board;
+import com.github.bhlangonijr.chesslib.Piece;
+
+public class WDLModel
+{
+	private final static double[] as = {-40.00676365, 98.77222217, -182.08209988, 340.61197659};
+	private final static double[] bs = {62.18462409, -195.09918531, 258.58208433, 1.29372611};
+	
+	@SuppressWarnings("unused")
+	private final static int NormalizeToPawnValue = 217;
+
+	private final static int PAWN_VALUE = 1;
+	private final static int KNIGHT_VALUE = 3;
+	private final static int BISHOP_VALUE = 3;
+	private final static int ROOK_VALUE = 5;
+	private final static int QUEEN_VALUE = 9;
+	
+	private static int countMaterial(Board board)
+	{
+		return Long.bitCount(board.getBitboard(Piece.WHITE_PAWN)) * PAWN_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.WHITE_KNIGHT)) * KNIGHT_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.WHITE_BISHOP)) * BISHOP_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.WHITE_ROOK)) * ROOK_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.WHITE_QUEEN)) * QUEEN_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.BLACK_PAWN)) * PAWN_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.BLACK_KNIGHT)) * KNIGHT_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.BLACK_BISHOP)) * BISHOP_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.BLACK_ROOK)) * ROOK_VALUE
+		+ Long.bitCount(board.getBitboard(Piece.BLACK_QUEEN)) * QUEEN_VALUE;
+	}
+	
+	private static double[] calculateParameters(Board board)
+	{
+		int material = countMaterial(board);
+		
+		material = Math.max(material, 17);
+		material = Math.min(material, 78);
+		
+		double m = material / 58.0;
+		
+		double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
+	    double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
+		
+		return new double[]{a, b};
+	}
+	
+	private static int calculateWinRate(int v, Board board)
+	{
+		double[] parameters = calculateParameters(board);
+		
+	    return (int)(0.5 + 1000 / (1 + Math.exp((parameters[0] - (double) v) / parameters[1])));
+	}
+	
+	public static int[] calculateWDL(int v, Board board)
+	{
+		int winRate = calculateWinRate(v, board);
+		int lossRate = calculateWinRate(-v, board);
+		int drawRate = 1000 - winRate - lossRate;
+		
+		return new int[] {winRate, drawRate, lossRate};
+	}
+	
+	public static int normalizeEval(int v, Board board)
+	{
+		double a = calculateParameters(board)[0];
+		
+		return (int) Math.round((100 * v) / a);
+	}
+}


### PR DESCRIPTION
Using https://github.com/official-stockfish/WDL_model, fit the default WDL model on [30k STC games](https://chess.aronpetkovski.com/test/1200/). Also normalizes centipawn evaluation such that 100cp = 50% chance of drawing.

![scoreWDL](https://github.com/xu-shawn/Serendipity/assets/50402888/1b6beb28-a7d9-4831-8198-7a5bb992766c)

```
❯ python3 scoreWDL.py --NormalizeToPawnValue 100
Converting evals with NormalizeToPawnValue = 100.
Reading eval stats from scoreWDLstat.json.
Retained (W,D,L) = (112510, 310494, 112805) positions.
Fit WDL model based on material.
Initial objective function:  0.7034662546449925
Final objective function:    0.7034635711640879
Optimization terminated successfully.
const int NormalizeToPawnValue = 217;
Corresponding spread = 127;
Corresponding normalized spread = 0.5842796812816458;
Draw rate at 0.0 eval at material 58 = 0.6940638417885613;
Parameters in internal value units: 
p_a = ((-40.007 * x / 58 + 98.772) * x / 58 + -182.082) * x / 58 + 340.612
p_b = ((62.185 * x / 58 + -195.099) * x / 58 + 258.582) * x / 58 + 1.294
    constexpr double as[] = {-40.00676365, 98.77222217, -182.08209988, 340.61197659};
    constexpr double bs[] = {62.18462409, -195.09918531, 258.58208433, 1.29372611};
```