### PR TITLE
Update WDL Model

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
@@ -9,7 +9,7 @@ public class WDLModel
 	private final static double[] bs = { -47.75093113, 118.81734426, -33.05800930, 94.01690687 };
 
 	@SuppressWarnings("unused")
-	private final static int NormalizeToPawnValue = 217;
+	private final static int NormalizeToPawnValue = 236;
 
 	private final static int PAWN_VALUE = 1;
 	private final static int KNIGHT_VALUE = 3;

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/WDLModel.java
@@ -5,9 +5,9 @@ import com.github.bhlangonijr.chesslib.Piece;
 
 public class WDLModel
 {
-	private final static double[] as = {-40.00676365, 98.77222217, -182.08209988, 340.61197659};
-	private final static double[] bs = {62.18462409, -195.09918531, 258.58208433, 1.29372611};
-	
+	private final static double[] as = { -117.29796837, 388.52982654, -512.96172771, 477.99147478 };
+	private final static double[] bs = { -47.75093113, 118.81734426, -33.05800930, 94.01690687 };
+
 	@SuppressWarnings("unused")
 	private final static int NormalizeToPawnValue = 217;
 
@@ -16,56 +16,56 @@ public class WDLModel
 	private final static int BISHOP_VALUE = 3;
 	private final static int ROOK_VALUE = 5;
 	private final static int QUEEN_VALUE = 9;
-	
+
 	private static int countMaterial(Board board)
 	{
 		return Long.bitCount(board.getBitboard(Piece.WHITE_PAWN)) * PAWN_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.WHITE_KNIGHT)) * KNIGHT_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.WHITE_BISHOP)) * BISHOP_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.WHITE_ROOK)) * ROOK_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.WHITE_QUEEN)) * QUEEN_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.BLACK_PAWN)) * PAWN_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.BLACK_KNIGHT)) * KNIGHT_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.BLACK_BISHOP)) * BISHOP_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.BLACK_ROOK)) * ROOK_VALUE
-		+ Long.bitCount(board.getBitboard(Piece.BLACK_QUEEN)) * QUEEN_VALUE;
+				+ Long.bitCount(board.getBitboard(Piece.WHITE_KNIGHT)) * KNIGHT_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.WHITE_BISHOP)) * BISHOP_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.WHITE_ROOK)) * ROOK_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.WHITE_QUEEN)) * QUEEN_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.BLACK_PAWN)) * PAWN_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.BLACK_KNIGHT)) * KNIGHT_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.BLACK_BISHOP)) * BISHOP_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.BLACK_ROOK)) * ROOK_VALUE
+				+ Long.bitCount(board.getBitboard(Piece.BLACK_QUEEN)) * QUEEN_VALUE;
 	}
-	
+
 	private static double[] calculateParameters(Board board)
 	{
 		int material = countMaterial(board);
-		
+
 		material = Math.max(material, 17);
 		material = Math.min(material, 78);
-		
+
 		double m = material / 58.0;
-		
+
 		double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
-	    double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
-		
-		return new double[]{a, b};
+		double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];
+
+		return new double[] { a, b };
 	}
-	
+
 	private static int calculateWinRate(int v, Board board)
 	{
 		double[] parameters = calculateParameters(board);
-		
-	    return (int)(0.5 + 1000 / (1 + Math.exp((parameters[0] - (double) v) / parameters[1])));
+
+		return (int) (0.5 + 1000 / (1 + Math.exp((parameters[0] - (double) v) / parameters[1])));
 	}
-	
+
 	public static int[] calculateWDL(int v, Board board)
 	{
 		int winRate = calculateWinRate(v, board);
 		int lossRate = calculateWinRate(-v, board);
 		int drawRate = 1000 - winRate - lossRate;
-		
-		return new int[] {winRate, drawRate, lossRate};
+
+		return new int[] { winRate, drawRate, lossRate };
 	}
-	
+
 	public static int normalizeEval(int v, Board board)
 	{
 		double a = calculateParameters(board)[0];
-		
+
 		return (int) Math.round((100 * v) / a);
 	}
 }


### PR DESCRIPTION
6x More data from various non-regression tests mainly relating to resizable hash.

https://chess.aronpetkovski.com/test/1225/
https://chess.aronpetkovski.com/test/1250/
https://chess.aronpetkovski.com/test/1261/
https://chess.aronpetkovski.com/test/1263/
https://chess.aronpetkovski.com/test/1277/
https://chess.aronpetkovski.com/test/1357/

![scoreWDL](https://github.com/xu-shawn/Serendipity/assets/50402888/8014eb2f-70be-4ac2-9143-7b84b8fab95d)

```
❯ python3 scoreWDL.py --NormalizeData '{"momType": "material", "momMin": 17, "momMax": 78, "momTarget": 58, "as": [-40.00676365, 98.77222217, -182.08209988, 340.61197659]}'
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-40.00676365, 98.77222217, -182.08209988, 340.61197659]}.
Reading eval stats from scoreWDLstat.json.
Retained (W,D,L) = (824989, 1928200, 825371) positions.
Fit WDL model based on material.
Initial objective function:  0.6350481731497092
Final objective function:    0.6350379750816926
Optimization terminated successfully.
const int NormalizeToPawnValue = 236;
Corresponding spread = 132;
Corresponding normalized spread = 0.558809843707221;
Draw rate at 0.0 eval at material 58 = 0.7137362232663982;
Parameters in internal value units: 
p_a = ((-117.298 * x / 58 + 388.530) * x / 58 + -512.962) * x / 58 + 477.991
p_b = ((-47.751 * x / 58 + 118.817) * x / 58 + -33.058) * x / 58 + 94.017
    constexpr double as[] = {-117.29796837, 388.52982654, -512.96172771, 477.99147478};
    constexpr double bs[] = {-47.75093113, 118.81734426, -33.05800930, 94.01690687};
```