### PR TITLE
Use Partial Search Results

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -748,7 +748,7 @@ public class AlphaBeta
 
 		if (!suppressOutput)
 		{
-			UCI.reportBestMove(lastCompletePV[0]);
+			UCI.reportBestMove(pv[0][0]);
 		}
 	}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/AlphaBeta.java
@@ -45,6 +45,8 @@ public class AlphaBeta
 	private Board internalBoard;
 	private Limits limits;
 
+	private Move bestMove;
+
 	public AlphaBeta(TranspositionTable tt, NNUE network)
 	{
 		this.nodesCount = 0;
@@ -613,6 +615,9 @@ public class AlphaBeta
 			{
 				alpha = thisMoveEval;
 
+				if (ply == 0)
+					this.bestMove = move;
+
 				if (alpha >= beta)
 				{
 					tt.write(board.getIncrementalHashKey(), TranspositionTable.NodeType.LOWERBOUND, depth, bestValue,
@@ -702,6 +707,7 @@ public class AlphaBeta
 			{
 				rootDepth = i;
 				selDepth = 0;
+				this.bestMove = null;
 
 				if (i > 3)
 				{
@@ -748,7 +754,7 @@ public class AlphaBeta
 
 		if (!suppressOutput)
 		{
-			UCI.reportBestMove(pv[0][0]);
+			UCI.reportBestMove(this.bestMove == null ? lastCompletePV[0] : this.bestMove);
 		}
 	}
 


### PR DESCRIPTION
Elo   | 1.14 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -1.70 (-2.94, 2.94) [0.00, 5.00]
Games | N: 120172 W: 28620 L: 28226 D: 63326
Penta | [1011, 12369, 33062, 12503, 1141]
https://chess.aronpetkovski.com/test/1830/

Elo   | 26.25 +- 9.77 (95%)
SPRT  | N=20000 Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1684 W: 543 L: 416 D: 725
Penta | [13, 142, 444, 191, 52]
https://chess.aronpetkovski.com/test/1829/