### PR TITLE
Adjust LMR Reduction With History

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -577,6 +577,10 @@ public class AlphaBeta
 				r -= isPV ? 1 : 0;
 				r -= givesCheck ? 1 : 0;
 				r += cutNode ? 1 : 0;
+				
+				final int history = threadData.history.get(board, move) + 4500;
+				
+				r -= history / 5000;
 
 				int d = newdepth - r;
 				d = Math.min(newdepth, newdepth - r);


### PR DESCRIPTION
Elo   | 5.39 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10574 W: 2726 L: 2562 D: 5286
Penta | [115, 1235, 2447, 1351, 139]
https://chess.aronpetkovski.com/test/2788/

bench 1941693