### PR TITLE
Check Time in Qsearch

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -159,6 +159,16 @@ public class AlphaBeta implements Runnable
 		{
 			return DRAW_EVAL;
 		}
+		
+		if ((this.threadData.nodes.get() & 1023) == 0 && this.shouldStop())
+		{
+			if (threadData.id == 0)
+			{
+				sharedThreadData.stopped.set(true);
+			}
+
+			throw new TimeOutException();
+		}
 
 		boolean isPV = beta - alpha > 1;
 


### PR DESCRIPTION
Elo   | 2.84 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9042 W: 2190 L: 2116 D: 4736
Penta | [64, 939, 2463, 969, 86]
https://chess.aronpetkovski.com/test/3535/

bench 1896266