### PR TITLE
Simplify QS Movesort

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -110,20 +110,6 @@ public class AlphaBeta implements Runnable
 		return v;
 	}
 
-	private void sortMoves(List<Move> moves, Board board, int ply)
-	{
-		TranspositionTable.Entry currentMoveEntry = sharedThreadData.tt.probe(board.getIncrementalHashKey());
-
-		Move ttMove = currentMoveEntry.hit() ? currentMoveEntry.getMove() : null;
-
-		History[] currentContinuationHistories = new History[] { ss.get(ply - 1).continuationHistory,
-				ss.get(ply - 2).continuationHistory, null, ss.get(ply - 4).continuationHistory, null,
-				ss.get(ply - 6).continuationHistory };
-
-		MoveSort.sortMoves(moves, ttMove, null, threadData.history, threadData.captureHistory,
-				currentContinuationHistories, board);
-	}
-
 	private void updateContinuationHistories(int ply, int depth, Board board, Move move, List<Move> quietsSearched)
 	{
 		History conthist;
@@ -212,7 +198,13 @@ public class AlphaBeta implements Runnable
 		{
 			bestScore = futilityBase = MIN_EVAL;
 			moves = board.legalMoves();
-			sortMoves(moves, board, ply);
+
+			History[] currentContinuationHistories = new History[] { ss.get(ply - 1).continuationHistory,
+					ss.get(ply - 2).continuationHistory, null, ss.get(ply - 4).continuationHistory, null,
+					ss.get(ply - 6).continuationHistory };
+
+			MoveSort.sortMoves(moves, ttMove, null, threadData.history, threadData.captureHistory,
+					currentContinuationHistories, board);
 		}
 
 		else
@@ -239,7 +231,7 @@ public class AlphaBeta implements Runnable
 
 			futilityBase = sse.staticEval + 205;
 			moves = board.pseudoLegalCaptures();
-			MoveSort.sortCaptures(moves, board, threadData.captureHistory);
+			MoveSort.sortCaptures(moves, ttMove, board, threadData.captureHistory);
 		}
 
 		for (Move move : moves)

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/MoveSort.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/MoveSort.java
@@ -78,26 +78,26 @@ public class MoveSort
 		}
 
 		moves.sort((m1, m2) -> {
-            if (((ScoredMove) m2).getScore() > ((ScoredMove) m1).getScore())
-            {
-                return 1;
-            }
+			if (((ScoredMove) m2).getScore() > ((ScoredMove) m1).getScore())
+			{
+				return 1;
+			}
 
-            else if (((ScoredMove) m2).getScore() == ((ScoredMove) m1).getScore())
-            {
-                return 0;
-            }
+			else if (((ScoredMove) m2).getScore() == ((ScoredMove) m1).getScore())
+			{
+				return 0;
+			}
 
-            return -1;
-        });
+			return -1;
+		});
 	}
 
-	public static void sortCaptures(List<Move> moves, Board board, History captureHistory)
+	public static void sortCaptures(List<Move> moves, Move ttMove, Board board, History captureHistory)
 	{
 		for (int i = 0; i < moves.size(); i++)
 		{
 			Move move = moves.get(i);
-			int value = qSearchValue(move, board, captureHistory);
+			int value = (move.equals(ttMove)) ? 2000000000 : qSearchValue(move, board, captureHistory);
 			moves.set(i, new ScoredMove(move, value));
 		}
 


### PR DESCRIPTION
Elo   | 1.29 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14850 W: 3520 L: 3465 D: 7865
Penta | [133, 1711, 3678, 1774, 129]
https://chess.aronpetkovski.com/test/4324/

bench 1843601