### PR TITLE
Fix illegal moves

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Chess/move/MoveList.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Chess/move/MoveList.java
@@ -786,7 +786,6 @@ public class MoveList extends LinkedList<Move> implements List<Move>
 		}
 		else
 		{
-
 			String strFrom = (san.contains("x") ? StringUtil.beforeSequence(san, "x")
 					: san.substring(0, san.length() - 2));
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -769,8 +769,7 @@ public class AlphaBeta implements Runnable
 		Move[] lastCompletePV = null;
 		alpha = MIN_EVAL;
 		beta = MAX_EVAL;
-		delta = 25;
-		clearPV();
+		delta = VALUE_NONE;
 
 		try
 		{
@@ -789,8 +788,8 @@ public class AlphaBeta implements Runnable
 				if (i > 3)
 				{
 					delta = 25;
-					alpha = currentScore - delta;
-					beta = currentScore + delta;
+					alpha = Math.max(currentScore - delta, MIN_EVAL);
+					beta = Math.min(currentScore + delta, MAX_EVAL);
 				}
 
 				while (true)
@@ -945,6 +944,8 @@ public class AlphaBeta implements Runnable
 		this.sharedThreadData.stopped.set(false);
 		this.accumulators = new AccumulatorStack(sharedThreadData.network);
 		this.accumulators.init(this.internalBoard);
+		this.bestMove = null;
+		clearPV();
 
 		iterativeDeepening(false);
 	}


### PR DESCRIPTION
Fixes a bug with clearing bestMove, which was introduced in #143

```
Elo   | -9.35 +- 13.48 (95%)
Conf  | 1.0+0.04s Threads=1 Hash=8MB
Games | N: 1004 W: 257 L: 284 D: 463
Penta | [25, 118, 235, 107, 17]
```
https://furybench.com/test/205/

bench 1266461