### PR TITLE
Cutnode NMP

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -473,7 +473,7 @@ public class AlphaBeta implements Runnable
 			return beta > -MATE_IN_MAX_PLY ? beta + (eval - beta) / 3 : eval;
 		}
 
-		if (!inSingularSearch && ply > 0 && eval >= beta && beta < MATE_IN_MAX_PLY && !inCheck
+		if (!inSingularSearch && cutNode && ply > 0 && eval >= beta && beta < MATE_IN_MAX_PLY && !inCheck
 				&& (ss.get(-1).move == null || !ss.get(-1).move.equals(Constants.emptyMove))
 				&& board.hasNonPawnMaterial())
 		{


### PR DESCRIPTION
```
Elo   | 2.03 +- 1.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 61646 W: 14426 L: 14066 D: 33154
Penta | [465, 7393, 14779, 7689, 497]
```
https://furybench.com/test/267/

bench 1197652