### PR TITLE
Reduce Aspiration Search Depth on Fail High

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -773,28 +773,30 @@ public class AlphaBeta implements Runnable
 
 		try
 		{
-			for (int i = 1; i < MAX_PLY; i++)
+			for (int rootDepth = 1; rootDepth < MAX_PLY; rootDepth++)
 			{
-				if (this.threadData.id == 0 && (i > this.threadData.mainThreadData.limits.getDepth()
+				if (this.threadData.id == 0 && (rootDepth > this.threadData.mainThreadData.limits.getDepth()
 						|| this.timeManager.shouldStopIterativeDeepening()))
 				{
 					break;
 				}
 
-				threadData.rootDepth = i;
+				threadData.rootDepth = rootDepth;
 				threadData.selDepth = 0;
 				this.bestMove = null;
 
-				if (i > 3)
+				if (rootDepth > 3)
 				{
 					delta = 25;
 					alpha = Math.max(currentScore - delta, MIN_EVAL);
 					beta = Math.min(currentScore + delta, MAX_EVAL);
 				}
 
+				int failHighCount = 0;
+
 				while (true)
 				{
-					int newScore = mainSearch(this.internalBoard, i, alpha, beta, 0, false);
+					int newScore = mainSearch(this.internalBoard, rootDepth - failHighCount, alpha, beta, 0, false);
 
 					if (newScore > alpha && newScore < beta)
 					{
@@ -810,7 +812,7 @@ public class AlphaBeta implements Runnable
 								totalNodes += thread.getNodesCount();
 							}
 
-							SearchReport report = new SearchReport(i, threadData.selDepth, totalNodes,
+							SearchReport report = new SearchReport(rootDepth, threadData.selDepth, totalNodes,
 									sharedThreadData.tt.hashfull(), currentScore, this.timeManager.timePassed(),
 									this.internalBoard, lastCompletePV);
 
@@ -825,12 +827,14 @@ public class AlphaBeta implements Runnable
 
 					else if (newScore <= alpha)
 					{
+						failHighCount = 0;
 						beta = (alpha + beta) / 2;
 						alpha = Math.max(alpha - delta, MIN_EVAL);
 					}
 
 					else
 					{
+						failHighCount++;
 						beta = Math.min(beta + delta, MAX_EVAL);
 					}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -796,7 +796,8 @@ public class AlphaBeta implements Runnable
 
 				while (true)
 				{
-					int newScore = mainSearch(this.internalBoard, rootDepth - failHighCount, alpha, beta, 0, false);
+					int newScore = mainSearch(this.internalBoard, rootDepth - Math.min(failHighCount, 3), alpha, beta,
+							0, false);
 
 					if (newScore > alpha && newScore < beta)
 					{


### PR DESCRIPTION
```
Elo   | 7.46 +- 4.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6290 W: 1492 L: 1357 D: 3441
Penta | [27, 711, 1563, 788, 56]
```
https://furybench.com/test/410/

bench 730811