### PR TITLE
Fix Promotion TT Moves

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Chess/move/Move.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Chess/move/Move.java
@@ -193,7 +193,7 @@ public class Move
 
 	public int asBytes()
 	{
-		int promotionBits = 0; // isPromotion() ? (0b1000 | (promotion.ordinal() - 1)) : 0;
+		int promotionBits = isPromotion() ? (0b1000 | (promotion.ordinal() - 1)) : 0;
 		return (promotionBits << 12) | (getFrom().ordinal() << 6) | getTo().ordinal();
 	}
 

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -578,7 +578,7 @@ public class AlphaBeta implements Runnable
 
 			int extension = 0;
 
-			if (!inSingularSearch && ply > 0 && sse.ttHit && move.equals(ttMove) && depth >= 4
+			if (!inSingularSearch && ply > 0 && sse.ttHit && move.equals(ttMove) && !ttMove.isPromotion() && depth >= 4
 					&& Math.abs(currentMoveEntry.getEvaluation()) < MATE_IN_MAX_PLY
 					&& (currentMoveEntry.getNodeType() == TranspositionTable.NODETYPE_EXACT
 							|| currentMoveEntry.getNodeType() == TranspositionTable.NODETYPE_LOWERBOUND)
@@ -597,7 +597,7 @@ public class AlphaBeta implements Runnable
 				{
 					extension = 1;
 
-					if (!isPV && !ttMove.isPromotion())
+					if (!isPV)
 					{
 						extension = 2;
 					}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -597,7 +597,7 @@ public class AlphaBeta implements Runnable
 				{
 					extension = 1;
 
-					if (!isPV)
+					if (!isPV && !ttMove.isPromotion())
 					{
 						extension = 2;
 					}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -577,7 +577,7 @@ public class AlphaBeta implements Runnable
 
 			int extension = 0;
 
-			if (!inSingularSearch && ply > 0 && sse.ttHit && move.equals(ttMove) && !ttMove.isPromotion() && depth >= 4
+			if (!inSingularSearch && ply > 0 && sse.ttHit && move.equals(ttMove) && depth >= 4
 					&& Math.abs(currentMoveEntry.getEvaluation()) < MATE_IN_MAX_PLY
 					&& (currentMoveEntry.getNodeType() == TranspositionTable.NODETYPE_EXACT
 							|| currentMoveEntry.getNodeType() == TranspositionTable.NODETYPE_LOWERBOUND)
@@ -596,7 +596,7 @@ public class AlphaBeta implements Runnable
 				{
 					extension = 1;
 
-					if (!isPV)
+					if (!isPV && !ttMove.isPromotion())
 					{
 						extension = 2;
 					}

--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/Search/AlphaBeta.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.concurrent.BrokenBarrierException;
 
 import org.shawn.games.Serendipity.NNUE.*;
-import org.shawn.games.Serendipity.Search.Debug.Debugger;
 import org.shawn.games.Serendipity.Search.History.History;
 import org.shawn.games.Serendipity.Search.Listener.FinalReport;
 import org.shawn.games.Serendipity.Search.Listener.ISearchListener;
@@ -317,7 +316,7 @@ public class AlphaBeta implements Runnable
 		this.threadData.selDepth = Math.max(this.threadData.selDepth, ply);
 
 		boolean improving, isPV, inCheck, inSingularSearch;
-		boolean ttPV, ttCapture;
+		boolean ttCapture;
 		Move bestMove, ttMove;
 		int bestValue;
 		int eval;

--- a/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
+++ b/Serendipity/src/test/java/org/shawn/games/Serendipity/TranspositionTableTest.java
@@ -58,7 +58,7 @@ public class TranspositionTableTest
 
 		tt.write(null, board.getIncrementalHashKey(), TranspositionTable.NODETYPE_NONE, TranspositionTable.DEPTH_QS,
 				-6900, new Move(Square.A7, Square.A8, PieceType.KNIGHT), -200);
-		// assertEquals(new Move(Square.A7, Square.A8, PieceType.KNIGHT),
-		// tt.probe(board.getIncrementalHashKey()).getMove());
+		assertEquals(new Move(Square.A7, Square.A8, PieceType.KNIGHT),
+				tt.probe(board.getIncrementalHashKey()).getMove());
 	}
 }


### PR DESCRIPTION
Failed Non-regression STC:
```
Elo   | -4.65 +- 4.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6494 W: 1460 L: 1547 D: 3487
Penta | [56, 786, 1641, 717, 47]
```
https://furybench.com/test/571/

Passed Non-regression LTC:
```
Elo   | -0.83 +- 1.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 84640 W: 18109 L: 18311 D: 48220
Penta | [192, 9941, 22283, 9685, 219]
```
https://furybench.com/test/608/

bench 1050971