### PR TITLE
Update WDL Model

### DIFF
--- a/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI/WDLModel.java
+++ b/Serendipity/src/main/java/org/shawn/games/Serendipity/UCI/WDLModel.java
@@ -24,11 +24,11 @@ import org.shawn.games.Serendipity.Chess.Piece;
 
 public class WDLModel
 {
-	private final static double[] as = { -117.29796837, 388.52982654, -512.96172771, 477.99147478 };
-	private final static double[] bs = { -47.75093113, 118.81734426, -33.05800930, 94.01690687 };
+	private final static double[] as = { -278.87388531, 792.92105507, -790.09312301, 502.89054650 };
+	private final static double[] bs = { -84.42811086, 271.38296047, -230.42218354, 118.07436762 };
 
 	@SuppressWarnings("unused")
-	private final static int NormalizeToPawnValue = 236;
+	private final static int NormalizeToPawnValue = 227;
 
 	private final static int PAWN_VALUE = 1;
 	private final static int KNIGHT_VALUE = 3;


### PR DESCRIPTION
84k LTC games from #170

https://furybench.com/test/608/

![scoreWDL](https://github.com/user-attachments/assets/83396935-9334-43f8-9e84-c39e4eb5d939)

```
❯ uv run scoreWDL.py --NormalizeData '{"momType": "material", "momMin": 17, "momMax": 78, "momTarget": 58, "as": [-117.29796837, 388.52982654, -512.96172771, 477.99147478]}'
Converting evals with NormalizeData = {'momType': 'material', 'momMin': 17, 'momMax': 78, 'momTarget': 58, 'as': [-117.29796837, 388.52982654, -512.96172771, 477.99147478]}.
Reading eval stats from scoreWDLstat.json.
Retained (W,D,L) = (1146564, 3322350, 1145721) positions.
Fit WDL model based on material.
Initial objective function:  0.4619029762039201
Final objective function:    0.46190027243249787
Optimization terminated successfully.
const int NormalizeToPawnValue = 227;
Corresponding spread = 75;
Corresponding normalized spread = 0.3288905087623077;
Draw rate at 0.0 eval at material 58 = 0.9087434422326007;
Parameters in internal value units: 
p_a = ((-278.874 * x / 58 + 792.921) * x / 58 + -790.093) * x / 58 + 502.891
p_b = ((-84.428 * x / 58 + 271.383) * x / 58 + -230.422) * x / 58 + 118.074
    constexpr double as[] = {-278.87388531, 792.92105507, -790.09312301, 502.89054650};
    constexpr double bs[] = {-84.42811086, 271.38296047, -230.42218354, 118.07436762};
```

bench 1050971